### PR TITLE
Try and build a few astropy packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ install:
 
 build_script:
   - mkdir wheelhouse
-  - autowheel windows32 --output-dir=wheelhouse --ignore-existing
-  - autowheel windows64 --output-dir=wheelhouse --ignore-existing
+  - autowheel windows32 --output-dir=wheelhouse
+  - autowheel windows64 --output-dir=wheelhouse
   - dir wheelhouse
   - 7z a wheels_windows.zip wheelhouse
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ build_script:
   - autowheel windows32 --output-dir=wheelhouse --ignore-existing
   - autowheel windows64 --output-dir=wheelhouse --ignore-existing
   - dir wheelhouse
-  - 7z a wheels.zip wheelhouse
+  - 7z a wheels_windows.zip wheelhouse
 
 artifacts:
-  - path: "wheels.zip"
+  - path: "wheels_windows.zip"
     name: Wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+environment:
+  global:
+    PYTHON: "C:\\Python36"
+
 install:
   - pip install git+https://github.com/astrofrog/autowheel.git
 

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -30,14 +30,6 @@
 
 - package_name: photutils
   pin_numpy: true
-  test_command: pytest -p no:warnings --pyargs photutils --noconftest
-  test_requires: numpy==1.15.4
-  python_versions:
-    '0.6':
-      - cp27
-
-- package_name: photutils
-  pin_numpy: true
   test_command: pytest -p no:warnings --pyargs photutils
   test_requires: pytest-astropy numpy==1.15.4
   python_versions:

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -13,7 +13,7 @@
 - package_name: astropy-healpix
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs astropy_healpix
-  test_requires: pytest numpy==1.15.4
+  test_requires: pytest-astropy numpy==1.15.4
   python_versions:
     '0.4':
       - cp27
@@ -24,7 +24,7 @@
 - package_name: photutils
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs photutils
-  test_requires: pytest numpy==1.15.4
+  test_requires: pytest-astropy numpy==1.15.4
   python_versions:
     '0.6':
       - cp27
@@ -35,7 +35,7 @@
 - package_name: regions
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs regions
-  test_requires: pytest numpy==1.15.4
+  test_requires: pytest-astropy numpy==1.15.4
   python_versions:
     '0.3':
       - cp27

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -30,6 +30,7 @@
 
 - package_name: photutils
   pin_numpy: true
+  pin_numy_min: 1.11.3
   test_command: pytest -p no:warnings --pyargs photutils
   test_requires: pytest-astropy numpy==1.15.4
   python_versions:

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -12,7 +12,7 @@
 
 - package_name: astropy-healpix
   pin_numpy: true
-  test_command: pytest -p no:warnings --pyargs astropy_healpix
+  test_command: pytest -p no:warnings --pyargs astropy_healpix --noconftest
   test_requires: numpy==1.15.4
   python_versions:
     '0.4':
@@ -30,7 +30,7 @@
 
 - package_name: photutils
   pin_numpy: true
-  test_command: pytest -p no:warnings --pyargs photutils
+  test_command: pytest -p no:warnings --pyargs photutils --noconftest
   test_requires: numpy==1.15.4
   python_versions:
     '0.6':
@@ -48,7 +48,7 @@
 
 - package_name: regions
   pin_numpy: true
-  test_command: pytest -p no:warnings --pyargs regions
+  test_command: pytest -p no:warnings --pyargs regions --noconftest
   test_requires: numpy==1.15.4
   python_versions:
     '0.3':

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -13,10 +13,17 @@
 - package_name: astropy-healpix
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs astropy_healpix
-  test_requires: pytest-astropy numpy==1.15.4
+  test_requires: numpy==1.15.4
   python_versions:
     '0.4':
       - cp27
+
+- package_name: astropy-healpix
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs astropy_healpix
+  test_requires: pytest-astropy numpy==1.15.4
+  python_versions:
+    '0.4':
       - cp35
       - cp36
       - cp37
@@ -24,10 +31,17 @@
 - package_name: photutils
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs photutils
-  test_requires: pytest-astropy numpy==1.15.4
+  test_requires: numpy==1.15.4
   python_versions:
     '0.6':
       - cp27
+
+- package_name: photutils
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs photutils
+  test_requires: pytest-astropy numpy==1.15.4
+  python_versions:
+    '0.6':
       - cp35
       - cp36
       - cp37
@@ -35,10 +49,17 @@
 - package_name: regions
   pin_numpy: true
   test_command: pytest -p no:warnings --pyargs regions
-  test_requires: pytest-astropy numpy==1.15.4
+  test_requires: numpy==1.15.4
   python_versions:
     '0.3':
       - cp27
+
+- package_name: regions
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs regions
+  test_requires: pytest-astropy numpy==1.15.4
+  python_versions:
+    '0.3':
       - cp35
       - cp36
       - cp37

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -9,3 +9,36 @@
       - cp35
       - cp36
       - cp37
+
+- package_name: astropy-healpix
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs astropy_healpix
+  test_requires: pytest numpy==1.15.4
+  python_versions:
+    '0.4':
+      - cp27
+      - cp35
+      - cp36
+      - cp37
+
+- package_name: photutils
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs photutils
+  test_requires: pytest numpy==1.15.4
+  python_versions:
+    '0.6':
+      - cp27
+      - cp35
+      - cp36
+      - cp37
+
+- package_name: regions
+  pin_numpy: true
+  test_command: pytest -p no:warnings --pyargs regions
+  test_requires: pytest numpy==1.15.4
+  python_versions:
+    '0.3':
+      - cp27
+      - cp35
+      - cp36
+      - cp37

--- a/autowheel.yml
+++ b/autowheel.yml
@@ -30,7 +30,7 @@
 
 - package_name: photutils
   pin_numpy: true
-  pin_numy_min: 1.11.3
+  pin_numpy_min: 1.11.3
   test_command: pytest -p no:warnings --pyargs photutils
   test_requires: pytest-astropy numpy==1.15.4
   python_versions:

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -30,7 +30,7 @@ jobs:
 
   - script: autowheel ${{ parameters.os }} --output-dir=wheelhouse --ignore-existing
     displayName: Running autowheel
-    ${{ if eq(parameters.os, 'macos') }}:
+    ${{ if eq(parameters.os, 'macosx') }}:
       env:
         CC: clang
 

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -28,7 +28,7 @@ jobs:
   - script: mkdir wheelhouse
     displayName: Making wheelhouse directory
 
-  - script: autowheel ${{ parameters.os }} --output-dir=wheelhouse --ignore-existing
+  - script: autowheel ${{ parameters.os }} --output-dir=wheelhouse
     displayName: Running autowheel
     ${{ if eq(parameters.os, 'macosx') }}:
       env:


### PR DESCRIPTION
One thing that is missing is the ability to provide a minimum Numpy version that can override the minimum versions determined by autowheel (in cases where the package requires functionality from a recent numpy)